### PR TITLE
Safer atomic transactions

### DIFF
--- a/lib/sidewalk/client.ex
+++ b/lib/sidewalk/client.ex
@@ -96,12 +96,9 @@ defmodule Sidewalk.Client do
     case Poison.encode(%{job | enqueued_at: current_unix_timestamp()}) do
       {:ok, encoded_job} ->
         :poolboy.transaction(:sidewalk_pool, fn(conn) ->
-          with  {:ok, _} <- Redix.command(conn, ~w(MULTI)),
-                {:ok, _} <- Redix.command(conn, ["SADD", namespacify("queues"), job.queue]),
-                {:ok, _} <- Redix.command(conn, ["LPUSH", namespacify("queue:#{job.queue}"), encoded_job]),
-                {:ok, _} <- Redix.command(conn, ~w(EXEC)),
-          do: {:ok, job.jid}
+          maybe_atomic_push(conn, job, encoded_job)
         end)
+
       {:error, error_message} ->
         {:error, "Unable to enqueue Job: #{error_message}"}
     end
@@ -138,5 +135,19 @@ defmodule Sidewalk.Client do
   defp current_unix_timestamp do
     {mega_seconds, seconds, microseconds} = :os.timestamp
     String.to_float("#{mega_seconds}#{seconds}.#{microseconds}")
+  end
+
+  defp maybe_atomic_push(conn, job, encoded_job) do
+    with \
+      {:ok, _} <- Redix.command(conn, ~w(MULTI)),
+      {:ok, _} <- Redix.command(conn, ["SADD", namespacify("queues"), job.queue]),
+      {:ok, _} <- Redix.command(conn, ["LPUSH", namespacify("queue:#{job.queue}"), encoded_job]),
+      {:ok, _} <- Redix.command(conn, ~w(EXEC))
+    do
+      {:ok, job.jid}
+    else
+      {:error, redix_error} ->
+        raise redix_error
+    end
   end
 end


### PR DESCRIPTION
If redis becomes unavailable due to network issues during an atomic transaction,
then redix will return an error and Sidewalk will stop executing the transaction
part way through. This leaves the redis connection in a "MULTI" state once the Redix connection
reconnects with the redis server. When the connection is re-used to push another
job the connection will crash with a `%Redix.Error{message: "ERR MULTI calls can not be nested"}` error.

After this change sidewalk will crash the redix connection process by raising
the `Redix.Error` if a transaction fails part way through. This will cause
poolboy to replace it with a fresh connection and effectively cleans up the
connection state.

We tested this by running multiple docker containers and disconnecting the
redis container after starting a `MULTI` transaction from a client conatiner.
Upon reconnecting the client container, we saw the `ERR MULTI calls can not be nested` error when trying to start a new transaction.