### PR TITLE
Support Modern Elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Sidewalk.Mixfile do
     [
       app: :sidewalk,
       version: "0.3.2",
-      elixir: "~> 1.4.0",
+      elixir: "~> 1.4",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description: description(),


### PR DESCRIPTION
Instead of demanding the patch bit on Elixir 1.4, let's allow modern
Elixir to be used too.