### PR TITLE
Support Active Job

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ For more information about Sidekiq please refer to http://sidekiq.org.
 To use Sidewalk you need to create a `%Sidewalk.Job{}` and enqueue it with one of the enqueue functions.
 
 ## Supported features
+
 * Redis namespaces as already known with Sidekiq
 * Ability to configure the Redis server and connection details
 * Enqueuing jobs to be executed immediately
 * Enqueuing jobs to be executed in X seconds
 * Enqueuing jobs to be executed at a specific time
+* Enqueue jobs that are Active Job compatible
 
 ## Installation
 1. Add `sidewalk` to your list of dependencies in `mix.exs`:
@@ -55,6 +57,11 @@ Sidewalk offers three modes for enqueuing jobs:
 ```elixir
 job = %Sidewalk.Job{class: "MyWorker", args: ['bob', 1, %{foo: 'bar'}]}
 {:ok, jid} = Sidewalk.Client.enqueue(job) # => jid: "2f87a952ced00ea6cdd61245"
+
+# And with Active Job:
+
+job = %Sidewalk.ActiveJob{job_class: "MyWorker", arguments: ["skippy", %{age: 21}]}
+{:ok, jid} = Sidewalk.Client.enqueue(job) # => jid: "2f87a952ced00ea6cdd61245"
 ```
 
 #### 2. Enqueuing a job with a delayed execution defined in seconds
@@ -64,6 +71,11 @@ job = %Sidewalk.Job{class: "MyWorker", args: ['bob', 1, %{foo: 'bar'}]}
 
 job = %Sidewalk.Job{class: "MyWorker", args: ['bob', 1, %{foo: 'bar'}]}
 {:ok, jid} = Sidewalk.Client.enqueue_in(job, 120) # => jid: "a805893e8bd98bf965d1dd54"
+
+# And with Active Job:
+
+job = %Sidewalk.ActiveJob{job_class: "MyWorker", arguments: ["anakin", 22, %{allegiance: "sith"}]}
+{:ok, jid} = Sidewalk.Client.enqueue_in(job, 120) # => jid: "a805893e8bd98bf965d1dd54"
 ```
 
 #### 3. Enqueuing a job to be executed at a specific time
@@ -72,6 +84,11 @@ job = %Sidewalk.Job{class: "MyWorker", args: ['bob', 1, %{foo: 'bar'}]}
 # The time when the job should be executed is defined as a unix timestamp
 
 job = %Sidewalk.Job{class: "MyWorker", args: ['bob', 1, %{foo: 'bar'}]}
+{:ok, jid} = Sidewalk.Client.enqueue_at(job, 1546293600) # => jid: "d6ceac7d6c42d35ff6cac8a0"
+
+# And with Active Job
+
+job = %Sidewalk.ActiveJob{job_class: "MyWorker", arguments: ["Obi-Wan", 33, %{allegiance: "jedi"}]}
 {:ok, jid} = Sidewalk.Client.enqueue_at(job, 1546293600) # => jid: "d6ceac7d6c42d35ff6cac8a0"
 ```
 

--- a/lib/sidewalk/active_job.ex
+++ b/lib/sidewalk/active_job.ex
@@ -1,0 +1,34 @@
+defmodule Sidewalk.ActiveJob do
+  @moduledoc """
+  This struct represents a job that will be compatible with ActiveJob.
+  """
+
+  # https://github.com/rails/rails/blob/1e8c791ed29aed7791bba5893d2a4d6e00341998/activejob/lib/active_job/core.rb#L84-L96
+
+  @derive [Poison.Encoder]
+  defstruct [
+    job_class: "",
+    job_id: "",
+    provider_job_id: "",
+    queue_name: "default",
+    priority:  "",
+    arguments: [],
+    executions: 0,
+    locale: "en",
+    enqueued_at: "",
+    retry: true,
+  ]
+
+  @type t :: %Sidewalk.ActiveJob{
+    job_class: String.t,
+    job_id: String.t,
+    provider_job_id: String.t,
+    queue_name: String.t,
+    priority: String.t,
+    arguments: List.t,
+    executions: pos_integer(),
+    locale: String.t,
+    enqueued_at: Float.t,
+    retry: boolean
+  }
+end

--- a/lib/sidewalk/client.ex
+++ b/lib/sidewalk/client.ex
@@ -10,10 +10,12 @@ defmodule Sidewalk.Client do
   For more information of the structure of a Sidewalk job, please have a look at the `Job` module.
   """
 
-  @type job           :: Sidewalk.Job.t
+  @type job           :: Sidewalk.Job.t | Sidewalk.ActiveJob.t
   @type enqueue_delay :: Integer.t
   @type enqueue_time  :: Integer.t
   @type response      :: {:ok, String.t} | {:error, String.t}
+
+  alias Sidewalk.{ActiveJob, Job}
 
   @doc """
   Jobs enqueued with this function will be executed by Sidekiq as soon as possible.
@@ -24,7 +26,10 @@ defmodule Sidewalk.Client do
       {:ok, jid} = Sidewalk.Client.enqueue(job) # => jid: "2f87a952ced00ea6cdd61245"
   """
   @spec enqueue(job) :: response
-  def enqueue(job=%Sidewalk.Job{}) do
+  def enqueue(job=%Job{}) do
+    with {:ok, normalized_job} <- normalize_job(job), do: atomic_push(normalized_job)
+  end
+  def enqueue(job=%ActiveJob{}) do
     with {:ok, normalized_job} <- normalize_job(job), do: atomic_push(normalized_job)
   end
   def enqueue(_) do
@@ -41,10 +46,10 @@ defmodule Sidewalk.Client do
   """
   @spec enqueue_in(job, enqueue_delay) :: response
   def enqueue_in(job, enqueue_in_seconds \\ 60)
-  def enqueue_in(job=%Sidewalk.Job{}, enqueue_in_seconds) when is_integer(enqueue_in_seconds) and enqueue_in_seconds > 0 do
+  def enqueue_in(job, enqueue_in_seconds) when is_integer(enqueue_in_seconds) and enqueue_in_seconds > 0 do
     enqueue_at(job, (current_unix_timestamp() + enqueue_in_seconds))
   end
-  def enqueue_in(job=%Sidewalk.Job{}, enqueue_in_seconds) when is_integer(enqueue_in_seconds) and enqueue_in_seconds <= 0 do
+  def enqueue_in(job, enqueue_in_seconds) when is_integer(enqueue_in_seconds) and enqueue_in_seconds <= 0 do
     enqueue(job)
   end
   def enqueue_in(_,_) do
@@ -61,34 +66,72 @@ defmodule Sidewalk.Client do
   """
   @spec enqueue_at(job, enqueue_time) :: response
   def enqueue_at(job, enqueue_at_timestamp \\ (current_unix_timestamp() + 60))
-  def enqueue_at(job=%Sidewalk.Job{}, enqueue_at_timestamp) when is_number(enqueue_at_timestamp) and enqueue_at_timestamp > 1_000_000_000 do
+  def enqueue_at(job=%Job{}, enqueue_at_timestamp) when is_number(enqueue_at_timestamp) and enqueue_at_timestamp > 1_000_000_000 do
+    handle_enqueue_at(job, enqueue_at_timestamp)
+  end
+  def enqueue_at(job=%ActiveJob{}, enqueue_at_timestamp) when is_number(enqueue_at_timestamp) and enqueue_at_timestamp > 1_000_000_000 do
+    handle_enqueue_at(job, enqueue_at_timestamp)
+  end
+  def enqueue_at(_,_) do
+    {:error, "Job must be a Sidewalk.Job with at least 'class' and 'args' set: %Sidewalk.Job{class: 'SomeWorker', args: ['bob', 1, %{foo: 'bar'}]} and a valid 'enqueue at' formated as unix timestamp"}
+  end
+
+  defp handle_enqueue_at(job, enqueue_at_timestamp) do
     if enqueue_at_timestamp <= current_unix_timestamp() do
       enqueue(job)
     else
       with {:ok, normalized_job} <- normalize_job(job), do: atomic_push(normalized_job, enqueue_at_timestamp)
     end
   end
-  def enqueue_at(_,_) do
-    {:error, "Job must be a Sidewalk.Job with at least 'class' and 'args' set: %Sidewalk.Job{class: 'SomeWorker', args: ['bob', 1, %{foo: 'bar'}]} and a valid 'enqueue at' formated as unix timestamp"}
-  end
-
 
   ############################################################
   ## --> HELPER FUNCTIONS
   @spec normalize_job(job) :: {:ok, job} | {:error, String.t}
-  defp normalize_job(job) do
-    case job do
-      %Sidewalk.Job{class: class} when not is_binary(class) or (is_binary(class) and byte_size(class) <= 0) ->
-        {:error, "Job class must be a valid String representation of the class name"}
-      %Sidewalk.Job{queue: queue} when not is_binary(queue) or (is_binary(queue) and byte_size(queue) <= 0) ->
-        {:error, "Job queue must be a valid String representation of the queue name"}
-      %Sidewalk.Job{args: args} when not is_list(args) ->
-        {:error, "Job args must be a List"}
-      %Sidewalk.Job{class: class, args: args} when is_binary(class) and byte_size(class) > 0 and is_list(args) ->
-        {:ok, %{job | jid: random_jid(), created_at: current_unix_timestamp()}}
-      _ ->
-        {:error, "Job must be a Sidewalk.Job with at least 'class' and 'args' set: %Sidewalk.Job{class: 'SomeWorker', args: ['bob', 1, %{foo: 'bar'}]}"}
-    end
+  defp normalize_job(%Job{class: class}) when not is_binary(class) or (is_binary(class) and byte_size(class) <= 0) do
+    {:error, "Job class must be a valid String representation of the class name"}
+  end
+  defp normalize_job(%Job{queue: queue}) when not is_binary(queue) or (is_binary(queue) and byte_size(queue) <= 0) do
+    {:error, "Job queue must be a valid String representation of the queue name"}
+  end
+  defp normalize_job(%Job{args: args}) when not is_list(args) do
+    {:error, "Job args must be a List"}
+  end
+  defp normalize_job(%ActiveJob{arguments: arguments}) when not is_list(arguments) do
+    {:error, "ActiveJob arguments must be a List"}
+  end
+  defp normalize_job(%Job{class: class}) when not is_binary(class) or (is_binary(class) and byte_size(class) <= 0) do
+    {:error, "Job class must be a valid String representation of the class name"}
+  end
+  defp normalize_job(%ActiveJob{job_class: class}) when not is_binary(class) or (is_binary(class) and byte_size(class) <= 0) do
+    {:error, "ActiveJob class must be a valid String representation of the class name"}
+  end
+  defp normalize_job(%Job{queue: queue}) when not is_binary(queue) or (is_binary(queue) and byte_size(queue) <= 0) do
+    {:error, "Job queue must be a valid String representation of the queue name"}
+  end
+  defp normalize_job(%ActiveJob{queue_name: queue}) when not is_binary(queue) or (is_binary(queue) and byte_size(queue) <= 0) do
+    {:error, "ActiveJob queue must be a valid String representation of the queue name"}
+  end
+  defp normalize_job(job = %Job{class: class, args: args}) when is_binary(class) and byte_size(class) > 0 and is_list(args) do
+    {:ok, %{job | jid: random_jid(), created_at: current_unix_timestamp()}}
+  end
+  defp normalize_job(active_job = %ActiveJob{job_class: class, arguments: args}) when is_binary(class) and byte_size(class) > 0 and is_list(args) do
+    # See https://github.com/rails/rails/blob/7dcfd30cd9655bbbccdbb31b1cdd4f1f575121c3/activejob/lib/active_job/queue_adapters/sidekiq_adapter.rb#L22-L26
+    {:ok, job_wrapper} = %Job{
+      class: "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+      wrapped: class,
+      queue: active_job.queue_name,
+      retry: active_job.retry
+    }
+    |> normalize_job()
+
+    active_job = %{active_job | job_id: job_wrapper.jid}
+
+    job_wrapper = %{job_wrapper | args: [active_job]}
+
+    {:ok, job_wrapper}
+  end
+  defp normalized_job(_) do
+    {:error, "Job must be a Sidewalk.Job with at least 'class' and 'args' set: %Sidewalk.Job{class: 'SomeWorker', args: ['bob', 1, %{foo: 'bar'}]}"}
   end
 
   @spec atomic_push(job) :: response

--- a/lib/sidewalk/job.ex
+++ b/lib/sidewalk/job.ex
@@ -11,6 +11,7 @@ defmodule Sidewalk.Job do
   - **enqueue_at**  -> The timestamp when the job is really enqueued with the Redis server.
   - **queue**       -> The queue where a job should be enqueued. Defaults to "default" queue.
   - **retry**       -> Tells the Sidekiq worker to retry the enqueue job.
+  - **wrapped**     -> Used by ActiveJob to indicate the job class to handle the payload
   """
 
   @derive [Poison.Encoder]
@@ -21,7 +22,8 @@ defmodule Sidewalk.Job do
     created_at: 0,
     enqueued_at: 0,
     queue: "default",
-    retry: true
+    retry: true,
+    wrapped: ""
   ]
 
   @type t :: %Sidewalk.Job{
@@ -31,6 +33,7 @@ defmodule Sidewalk.Job do
     created_at: Float.t,
     enqueued_at:  Float.t,
     queue: String.t,
-    retry: boolean
+    retry: boolean,
+    wrapped: String.t
   }
 end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,9 @@ defmodule Sidewalk.Mixfile do
 
   defp description do
     """
-    Sidewalk is an Elixir client which is compatible with Sidekiq, the »simple, efficient background processing library for Ruby«.
+    Sidewalk is an Elixir client which is compatible with Sidekiq, the »simple,
+    efficient background processing library for Ruby«. It is also compatible
+    when Active Job is used with Sidekiq.
     """
   end
 

--- a/test/sidewalk/client_test.exs
+++ b/test/sidewalk/client_test.exs
@@ -1,126 +1,264 @@
 defmodule Sidewalk.ClientTest do
   use ExUnit.Case
 
+  alias Sidewalk.{ActiveJob, Client, Job}
+
   setup do
     {:ok, conn} = Redix.start_link
     {:ok, "OK"} = Redix.command(conn, ~w(FLUSHDB))
     {:ok, [redis: conn]}
   end
 
-  ## --> Test enqueue functions with invalid parameters
-  test "enqueue/1 with invalid parameters" do
-    assert {:error, _} = Sidewalk.Client.enqueue("foo")
-    assert {:error, _} = Sidewalk.Client.enqueue(1)
-    assert {:error, _} = Sidewalk.Client.enqueue(%{})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: [], queue: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: ""})
+  describe "enqueue functions with invalid parameters" do
+    test "enqueue/1 with invalid parameters" do
+      assert {:error, _} = Client.enqueue("foo")
+      assert {:error, _} = Client.enqueue(1)
+      assert {:error, _} = Client.enqueue(%{})
+      assert {:error, _} = Client.enqueue(%Job{})
+      assert {:error, _} = Client.enqueue(%Job{class: ""})
+      assert {:error, _} = Client.enqueue(%Job{class: 1})
+      assert {:error, _} = Client.enqueue(%Job{class: "MyWorker", args: ""})
+      assert {:error, _} = Client.enqueue(%Job{class: "MyWorker", args: 1})
+      assert {:error, _} = Client.enqueue(%Job{class: "MyWorker", args: [], queue: 1})
+      assert {:error, _} = Client.enqueue(%Job{class: "MyWorker", args: [1,2,3], queue: ""})
+      assert {:error, _} = Client.enqueue(%ActiveJob{})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: ""})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: 1})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: ""})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: 1})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: [], queue_name: 1})
+      assert {:error, _} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: ""})
+    end
+
+    test "enqueue_in/2 with invalid parameters" do
+      assert {:error, _} = Client.enqueue_in("foo")
+      assert {:error, _} = Client.enqueue_in(1)
+      assert {:error, _} = Client.enqueue_in(%{})
+      assert {:error, _} = Client.enqueue_in(%Job{})
+      assert {:error, _} = Client.enqueue_in(%Job{class: ""})
+      assert {:error, _} = Client.enqueue_in(%Job{class: 1})
+      assert {:error, _} = Client.enqueue_in(%Job{class: "MyWorker", args: ""})
+      assert {:error, _} = Client.enqueue_in(%Job{class: "MyWorker", args: 1})
+      assert {:error, _} = Client.enqueue_in(%Job{class: "MyWorker", args: [], queue: 1})
+      assert {:error, _} = Client.enqueue_in(%Job{class: "MyWorker", args: [1,2,3], queue: ""})
+      assert {:error, _} = Client.enqueue_in(%Job{class: "MyWorker", args: [1,2,3], queue: "default"}, "")
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: ""})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: 1})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: ""})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: 1})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: [], queue_name: 1})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: ""})
+      assert {:error, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: "default"}, "")
+    end
+
+    test "enqueue_at/2 with invalid parameters" do
+      assert {:error, _} = Client.enqueue_at("foo")
+      assert {:error, _} = Client.enqueue_at(1)
+      assert {:error, _} = Client.enqueue_at(%{})
+      assert {:error, _} = Client.enqueue_at(%Job{})
+      assert {:error, _} = Client.enqueue_at(%Job{class: ""})
+      assert {:error, _} = Client.enqueue_at(%Job{class: 1})
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: ""})
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: 1})
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [], queue: 1})
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [1,2,3], queue: ""})
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [1,2,3], queue: "default"}, "")
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [1,2,3], queue: "default"}, 1)
+      assert {:error, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [1,2,3], queue: "default"}, 1)
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: ""})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: 1})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: ""})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: 1})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [], queue_name: 1})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: ""})
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: "default"}, "")
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: "default"}, 1)
+      assert {:error, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], queue_name: "default"}, 1)
+    end
   end
 
-  test "enqueue_in/2 with invalid parameters" do
-    assert {:error, _} = Sidewalk.Client.enqueue_in("foo")
-    assert {:error, _} = Sidewalk.Client.enqueue_in(1)
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%{})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: [], queue: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: "default"}, "")
+  describe "enqueue functions with valid parameters for a successful enqueuing" do
+    test "enqueue/1 with valid Job parameters" do
+      {:ok, jid} = Client.enqueue(%Job{class: "MyWorker", args: [1,2,3]})
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
+
+    test "enqueue/1 with valid ActiveJob parameters" do
+      {:ok, jid} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: [1, 2, 3]})
+
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
+
+    test "enqueue_in/2 with valid Job parameters" do
+      {:ok, jid} = Client.enqueue_in(%Job{class: "MyWorker", args: [1,2,3]}, 120)
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
+
+    test "enqueue_in/2 with valid ActiveJob parameters" do
+      {:ok, jid} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3]}, 120)
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
+
+    test "enqueue_at/2 with valid Job parameters" do
+      {:ok, jid} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3]}, 1_900_000_000)
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
+
+    test "enqueue_at/2 with valid ActiveJob parameters" do
+      {:ok, jid} = Sidewalk.Client.enqueue_at(%Sidewalk.ActiveJob{job_class: "MyWorker", arguments: [1,2,3]}, 1_900_000_000)
+      assert is_binary(jid)
+      assert String.length(jid) == 24
+    end
   end
 
-  test "enqueue_at/2 with invalid parameters" do
-    assert {:error, _} = Sidewalk.Client.enqueue_at("foo")
-    assert {:error, _} = Sidewalk.Client.enqueue_at(1)
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%{})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [], queue: 1})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: ""})
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: "default"}, "")
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: "default"}, 1)
-    assert {:error, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], queue: "default"}, 1)
+  describe "successful write to redis for Jobs" do
+    test "enqueue/1 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue(%Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"})
+      assert Redix.command!(redis, ~w(SISMEMBER queues foo)) == 1
+      stored_job = Redix.command!(redis, ~w(LPOP queue:foo))
+      |> Poison.decode!(as: %Job{})
+
+      assert is_binary(stored_job.jid)
+      assert String.length(stored_job.jid) == 24
+      assert stored_job.class == "MyWorker"
+      assert length(stored_job.args) == 3
+      assert stored_job.args == [1,2,3]
+      assert stored_job.queue == "foo"
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+    end
+
+    test "enqueue_in/2 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue_in(%Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"}, 60)
+      [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
+      stored_job = Poison.decode!(raw_stored_job, as: %Job{})
+      assert is_binary(stored_job.jid)
+      assert String.length(stored_job.jid) == 24
+      assert stored_job.class == "MyWorker"
+      assert length(stored_job.args) == 3
+      assert stored_job.args == [1,2,3]
+      assert stored_job.queue == "foo"
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+      assert String.to_float(raw_execution_time) > 1_000_000_000
+    end
+
+    test "enqueue_at/2 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue_at(%Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"}, 2_000_000_000)
+      [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
+      stored_job = Poison.decode!(raw_stored_job, as: %Job{})
+      assert is_binary(stored_job.jid)
+      assert String.length(stored_job.jid) == 24
+      assert stored_job.class == "MyWorker"
+      assert length(stored_job.args) == 3
+      assert stored_job.args == [1,2,3]
+      assert stored_job.queue == "foo"
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+      assert String.to_integer(raw_execution_time) == 2_000_000_000
+    end
   end
 
-  ## --> Test enqueue functions with valid parameters for a successfull enqueuing
-  test "enqueue/1 with valid parameters" do
-    {:ok, jid} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: [1,2,3]})
-    assert is_binary(jid)
-    assert String.length(jid) == 24
+  describe "successful write to redis for ActiveJobs" do
+    test "enqueue/1 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], retry: false, queue_name: "foo"})
+
+      assert Redix.command!(redis, ~w(SISMEMBER queues foo)) == 1
+
+      stored_job = Redix.command!(redis, ~w(LPOP queue:foo))
+      |> Poison.decode!(as: %Job{})
+
+      %{jid: stored_jid, queue: stored_queue_name} = stored_job
+
+      assert is_binary(stored_jid)
+      assert String.length(stored_jid) == 24
+      assert stored_queue_name == "foo"
+      assert stored_job.class == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+      assert stored_job.wrapped == "MyWorker"
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+
+      [active_job] = stored_job.args
+
+      assert active_job["arguments"] == [1, 2, 3]
+      assert active_job["job_class"] == "MyWorker"
+      assert active_job["job_id"] == stored_jid
+      assert active_job["queue_name"] == stored_queue_name
+      assert active_job["retry"] == false
+    end
+
+    test "enqueue_in/2 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue_in(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], retry: false, queue_name: "foo"}, 60)
+
+      [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
+
+      assert String.to_float(raw_execution_time) > 1_000_000_000
+
+      stored_job = Poison.decode!(raw_stored_job, as: %Job{})
+
+      %{jid: stored_jid, queue: stored_queue_name} = stored_job
+
+      assert is_binary(stored_jid)
+      assert String.length(stored_jid) == 24
+      assert stored_queue_name == "foo"
+      assert stored_job.class == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+      assert stored_job.wrapped == "MyWorker"
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+
+      [active_job] = stored_job.args
+
+      assert active_job["arguments"] == [1, 2, 3]
+      assert active_job["job_class"] == "MyWorker"
+      assert active_job["job_id"] == stored_jid
+      assert active_job["queue_name"] == stored_queue_name
+      assert active_job["retry"] == false
+    end
+
+    test "enqueue_at/2 to write data correctly to redis", %{redis: redis} do
+      assert {:ok, _} = Client.enqueue_at(%ActiveJob{job_class: "MyWorker", arguments: [1,2,3], retry: false, queue_name: "foo"}, 2_000_000_000)
+
+      [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
+
+      assert String.to_integer(raw_execution_time) == 2_000_000_000
+
+      stored_job = Poison.decode!(raw_stored_job, as: %Job{})
+
+      %{jid: stored_jid, queue: stored_queue_name} = stored_job
+
+      assert is_binary(stored_jid)
+      assert String.length(stored_jid) == 24
+      assert stored_queue_name == "foo"
+      assert stored_job.class == "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+      assert stored_job.wrapped == "MyWorker"
+      assert stored_job.retry == false
+      assert stored_job.enqueued_at > 0
+      assert stored_job.created_at > 0
+      assert stored_job.created_at < stored_job.enqueued_at
+
+      [active_job] = stored_job.args
+
+      assert active_job["arguments"] == [1, 2, 3]
+      assert active_job["job_class"] == "MyWorker"
+      assert active_job["job_id"] == stored_jid
+      assert active_job["queue_name"] == stored_queue_name
+      assert active_job["retry"] == false
+    end
   end
-
-  test "enqueue_in/2 with valid parameters" do
-    {:ok, jid} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: [1,2,3]}, 120)
-    assert is_binary(jid)
-    assert String.length(jid) == 24
-  end
-
-  test "enqueue_at/2 with valid parameters" do
-    {:ok, jid} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3]}, 1_900_000_000)
-    assert is_binary(jid)
-    assert String.length(jid) == 24
-  end
-
-  ## --> Test successfull write to redis
-  test "enqueue/1 to write data correctly to redis", %{redis: redis} do
-    assert {:ok, _} = Sidewalk.Client.enqueue(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"})
-    assert Redix.command!(redis, ~w(SISMEMBER queues foo)) == 1
-    stored_job = Redix.command!(redis, ~w(LPOP queue:foo))
-    |> Poison.decode!(as: %Sidewalk.Job{})
-
-    assert is_binary(stored_job.jid)
-    assert String.length(stored_job.jid) == 24
-    assert stored_job.class == "MyWorker"
-    assert length(stored_job.args) == 3
-    assert stored_job.args == [1,2,3]
-    assert stored_job.queue == "foo"
-    assert stored_job.retry == false
-    assert stored_job.enqueued_at > 0
-    assert stored_job.created_at > 0
-    assert stored_job.created_at < stored_job.enqueued_at
-  end
-
-  test "enqueue_in/2 to write data correctly to redis", %{redis: redis} do
-    assert {:ok, _} = Sidewalk.Client.enqueue_in(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"}, 60)
-    [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
-    stored_job = Poison.decode!(raw_stored_job, as: %Sidewalk.Job{})
-    assert is_binary(stored_job.jid)
-    assert String.length(stored_job.jid) == 24
-    assert stored_job.class == "MyWorker"
-    assert length(stored_job.args) == 3
-    assert stored_job.args == [1,2,3]
-    assert stored_job.queue == "foo"
-    assert stored_job.retry == false
-    assert stored_job.enqueued_at > 0
-    assert stored_job.created_at > 0
-    assert stored_job.created_at < stored_job.enqueued_at
-    assert String.to_float(raw_execution_time) > 1_000_000_000
-  end
-
-  test "enqueue_at/2 to write data correctly to redis", %{redis: redis} do
-    assert {:ok, _} = Sidewalk.Client.enqueue_at(%Sidewalk.Job{class: "MyWorker", args: [1,2,3], retry: false, queue: "foo"}, 2_000_000_000)
-    [raw_stored_job, raw_execution_time] = Redix.command!(redis, ~w(ZRANGE schedule 0 0 WITHSCORES))
-    stored_job = Poison.decode!(raw_stored_job, as: %Sidewalk.Job{})
-    assert is_binary(stored_job.jid)
-    assert String.length(stored_job.jid) == 24
-    assert stored_job.class == "MyWorker"
-    assert length(stored_job.args) == 3
-    assert stored_job.args == [1,2,3]
-    assert stored_job.queue == "foo"
-    assert stored_job.retry == false
-    assert stored_job.enqueued_at > 0
-    assert stored_job.created_at > 0
-    assert stored_job.created_at < stored_job.enqueued_at
-    assert String.to_integer(raw_execution_time) == 2_000_000_000
-  end
-
 end


### PR DESCRIPTION
Works just like regular Sidekiq jobs.

## Open Questions, and Problems

- [ ] There's a fair bit of duplication going on. In the Rails version of Active Job, it more clearly wraps the Sidekiq Client with an Active Job Client. Perhaps I should refactor this solution accordingly? On a similar note, perhaps these changes should live an entirely different library that merely consumes this one?
- [x] This PR assumes #4 is merged